### PR TITLE
@ngx-env: Fix localize issue #81

### DIFF
--- a/packages/angular/src/builders/utils/esbuild-index-html.ts
+++ b/packages/angular/src/builders/utils/esbuild-index-html.ts
@@ -1,7 +1,6 @@
 import { type Dict } from "@dotenv-run/core";
 import { readFileSync, writeFileSync } from "fs";
 import * as glob from "glob";
-import { resolve } from "path";
 import { variablesReducer } from "./variables-reducer";
 
 function replaceInFile(filePath: string, raw: Dict) {
@@ -26,7 +25,9 @@ export function indexHtml(
       replaceInFile(filePath, raw);
     });
     if (ssr) {
-      replaceInFile(resolve(outputDir, "server/index.server.html"), raw);
+      glob.sync(`${outputDir}/server/**/index.server.html`).forEach((filePath) => {
+        replaceInFile(filePath, raw);
+      });
     }
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
Fixes #81 by getting all the possible `index.server.html` files instead of a single one at root of output folder