### PR TITLE
fix: csr angular 19 support

### DIFF
--- a/packages/angular/src/builders/utils/index-html-build.ts
+++ b/packages/angular/src/builders/utils/index-html-build.ts
@@ -11,7 +11,7 @@ export function indexHtml(
   runtime = false
 ) {
   try {
-    glob.sync(`${browserOutputDir}/**/index.html`).forEach((filePath) => {
+    glob.sync(`${browserOutputDir}/**/index{.html,.csr.html}`).forEach((filePath) => {
       const html = readFileSync(filePath, "utf-8");
       const content = variablesReducer(html, raw); // Replace %VARIABLE% with the actual value
       try {


### PR DESCRIPTION
This PR updates the logic for processing HTML files in the browserOutputDir to support both index.html and index.csr.html

@see https://github.com/angular/angular-cli/blob/c81dd817dfd74a12ecfc51af612e91d4592ff000/packages/angular/build/src/builders/application/execute-post-bundle.ts#L32