### PR TITLE
Update domain for Turborepo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ await build({
 - ✅ Official recommendation in [dotenv documentation](https://www.dotenv.org/docs/frameworks/angular/vercel) 🔥
 - ✅ Webpack and ESBuild support 🚀
 - ✅ Runtime environment variables 🎉
-- ✅ Loading priorities of environment variables with Monorepo Support ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.) ✨
+- ✅ Loading priorities of environment variables with Monorepo Support ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.) ✨
 - ✅ Easy to use, no configuration required
 - ✅ Up to date with latest Angular versions
 - ✅ Supports all Angular CLI commands

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -10,7 +10,7 @@
 - ✅ Official recommendation in [dotenv documentation](https://www.dotenv.org/docs/frameworks/angular/vercel) 🔥
 - ✅ Webpack and ESBuild support 🚀
 - ✅ Runtime environment variables 🎉
-- ✅ Loading priorities of environment variables with Monorepo Support ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.) ✨
+- ✅ Loading priorities of environment variables with Monorepo Support ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.) ✨
 - ✅ Easy to use, no configuration required
 - ✅ Up to date with latest Angular versions
 - ✅ Supports all Angular CLI commands

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,7 +7,7 @@ A CLI tool to load command line and .env environment variables with monorepo sup
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Supports hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Supports hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 - ✅ Supports all platforms and languages (Node.js, Python...) `dotenv-run -- python main.py`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific environment (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 
 # Install

--- a/packages/esbuild/README.md
+++ b/packages/esbuild/README.md
@@ -5,7 +5,7 @@
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific environment (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 
 ## Install

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -5,7 +5,7 @@
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific environment (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 
 ## Install

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -5,7 +5,7 @@
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific environment (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 
 ## Install

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -5,7 +5,7 @@
 - ✅ Expand environment variables `API_URL=$API_BASE/users`
 - ✅ Define environment variables for a specific environment (e.g. `.env.production`)
 - ✅ Load priorities of `.env.*` files (e.g. `.env.production` > `.env`)
-- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turbo.build/), etc.)
+- ✅ Hierarchical cascading configuration in monorepo projects ([Nx](https://nx.dev), [Turbo](https://turborepo.com/), etc.)
   `apps/next-app/.env` > `apps/.env` > `.env`
 
 ## Install

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://turborepo.com/schema.json",
     "pipeline": {
         "build": {
             "dependsOn": [


### PR DESCRIPTION
We updated the domain for the Turborepo documentation, and am trying to make sure links get updated where I can find them.

Thanks for using Turborepo!