### PR TITLE
chore(esbuild): relax esbuild peer dependency range

### DIFF
--- a/packages/esbuild/CHANGELOG.md
+++ b/packages/esbuild/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dotenv-run/esbuild
 
+## 1.5.2
+
+### Patch Changes
+
+- Relax the `esbuild` peer dependency range to `>=0.21.0`.
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotenv-run/esbuild",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Run your scripts with dotenv variables",
   "homepage": "https://github.com/chihab/dotenv-run",
   "main": "dist/cjs/index.js",
@@ -29,7 +29,7 @@
     "@dotenv-run/core": "workspace:~1.3.7"
   },
   "peerDependencies": {
-    "esbuild": "^0.21.0"
+    "esbuild": ">=0.21.0"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",


### PR DESCRIPTION
## Summary
- Relax `@dotenv-run/esbuild` peer dependency range from `^0.21.0` to `>=0.21.0`
- Bump `@dotenv-run/esbuild` to `1.5.2`
- Add the corresponding `1.5.2` changelog entry

## Why
The current peer range was too strict and caused unnecessary peer dependency conflicts even though the package works with newer compatible `esbuild` 0.x releases.