### PR TITLE
docs(ngx-env): update demo label to v22 and fix broken sample-project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ await build({
 
 #### Demos
 
-- [v21 with vite/esbuild builder](https://stackblitz.com/edit/ngx-env-3ey8js?file=src%2Fapp.component.ts)
+- [v22 with vite/esbuild builder](https://stackblitz.com/edit/ngx-env-3ey8js?file=src%2Fapp.component.ts)
 - [v16 with webpack builder](https://stackblitz.com/edit/ngx-env?file=src%2Fapp.component.ts)
 
 ## Testimonials

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -25,7 +25,7 @@
 
 ## Quick Demo
 
-- [v21 with vite/esbuild builder](https://stackblitz.com/edit/ngx-env-3ey8js?file=src%2Fapp.component.ts)
+- [v22 with vite/esbuild builder](https://stackblitz.com/edit/ngx-env-3ey8js?file=src%2Fapp.component.ts)
 - [v16 with webpack builder](https://stackblitz.com/edit/ngx-env?file=src%2Fapp.component.ts)
 
 ## Testimonials
@@ -493,7 +493,7 @@ The webpack configuration might be different depending on your custom builder bu
 
 [@dotenv-run/webpack](https://github.com/chihab/dotenv-run) is created by the same author of `@ngx-env/builder` and is used by `@ngx-env/builder` under the hood.
 
-You can find a sample project using `@dotenv-run/webpack` [here](https://github.com/chihab/dotenv-run/tree/main/examples/apps/ng-app).
+You can find a sample project using `@dotenv-run/webpack` [here](https://github.com/chihab/dotenv-run/tree/main/examples/nx-workspace/apps/ng-app-webpack).
 
 Please give it a star if you find it useful. ❤️
 


### PR DESCRIPTION
Small docs fixes for `@ngx-env/builder` (the README ships in the published package, so these would otherwise go out with `22.0.0`).

## Changes

- **Fix broken sample-project link** — `packages/angular/README.md` pointed at `examples/apps/ng-app`, which 404s after the examples were reorganized under `examples/nx-workspace/apps/`. Now points at [`ng-app-webpack`](https://github.com/chihab/dotenv-run/tree/main/examples/nx-workspace/apps/ng-app-webpack) (the sample with a custom `webpack.config.ts`, matching the "using `@dotenv-run/webpack`" text).
- **Relabel the StackBlitz demo `v21` → `v22`** in both the root `README.md` and `packages/angular/README.md`, now that the builder targets Angular 22.

## Notes

- The StackBlitz URL itself is unchanged (same demo id `ngx-env-3ey8js`) — only the label. If that demo hasn't actually been updated to Angular 22 yet, let me know and I'll revert just the label.
- Verified the new link target directory exists in the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181uWSuY7aymLgS4gMnCJAv)_